### PR TITLE
Update: Loader.php, removed array type check to allow null values

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -87,7 +87,7 @@ class Loader
      * selection set.
      */
     function op_filter_graphql_connection_query_args(
-        array $query_args,
+        $query_args,
         AbstractConnectionResolver $resolver
     ) {
         $info = $resolver->getInfo();


### PR DESCRIPTION
Fixed plugin throwing an error when requesting enqueuedScripts, enqueuedStylesheets, roles, or anything else it wasn't accounting for by allowing null in those cases.